### PR TITLE
Print out the run log when done running RQCFilter

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.4.1
+    0.4.2
 
 owners:
     [msneddon, wjriehl]

--- a/lib/BBTools/utils/BBToolsRunner.py
+++ b/lib/BBTools/utils/BBToolsRunner.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import subprocess
 
 
@@ -9,8 +9,13 @@ class BBToolsRunner:
     def __init__(self, scratch_dir):
         self.scratch_dir = scratch_dir
 
-    def run(self, command, options):
-        ''' options is an array of command-line parameters passed to the RQCFilter App '''
+    def run(self, command, options, log_path=None):
+        """
+        command: string, the BBTools command to run
+        options: list, command-line parameters to pass to the BBTools app
+        log_path: string, the path to the standard generated log file. If not None, this will
+                  get dumped to stdout (and the SDK logs) after the run.
+        """
         command = [os.path.join(self.BBTOOLS_PATH, command)] + options
 
         print('In working directory: ' + ' '.join(command))
@@ -18,6 +23,15 @@ class BBToolsRunner:
 
         p = subprocess.Popen(command, cwd=self.scratch_dir, shell=False)
         exitCode = p.wait()
+
+        if log_path is not None:
+            if not os.path.exists(log_path):
+                print('Unable to print log file! File "{}" does not exist!'.format(log_path))
+            else:
+                print('==================== RUN LOG ====================')
+                with open(log_path, 'r') as log_file:
+                    print(log_file.read(), end="")
+                print('==================== END LOG ====================')
 
         if (exitCode == 0):
             print('Success, exit code was: ' + str(exitCode))

--- a/lib/BBTools/utils/RQCFilterRunner.py
+++ b/lib/BBTools/utils/RQCFilterRunner.py
@@ -7,7 +7,7 @@ from pprint import pprint
 from BBTools.utils.BBToolsRunner import BBToolsRunner
 from KBaseReport.KBaseReportClient import KBaseReport
 from commandbuilder import build_options
-from file_util import (
+from .file_util import (
     download_interleaved_reads,
     upload_interleaved_reads,
     pack_and_upload_folder,
@@ -72,7 +72,7 @@ class RQCFilterRunner:
         run_log = os.path.join(output_dir, 'run_log.txt')
         options = self._process_app_params_to_cli(io_params, app_params, output_dir, run_log, is_app)
         bbtools = BBToolsRunner(self.scratch_dir)
-        bbtools.run(self.RQCFILTER_CMD, options)
+        bbtools.run(self.RQCFILTER_CMD, options, log_path=run_log)
         return output_dir, run_log
 
     def _process_app_params_to_cli(self, io_params, app_params, output_dir, run_log, is_app):


### PR DESCRIPTION
After a run, this now reads in and dumps out the generated run_log.txt to stdout (and, therefore, to the SDK logging system). This should happen whether it finishes running successfully or not.

If that file doesn't exist, it plops out a friendly message.