### PR TITLE
PTV-1863: Fix tests but 1, update to py 3.8 & java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
-FROM kbase/kbase:sdkbase2.latest
-MAINTAINER KBase Developer
-# -----------------------------------------
-# In this section, you can install any system dependencies required
-# to run your App.  For instance, you could place an apt-get update or
-# install line here, a git checkout to download code, or run any other
-# installation scripts.
+FROM kbase/sdkpython:3.8.10
 
-# Here we install a python coverage tool and an
-# https library that is out of date in the base image.
+RUN apt update && apt install -y wget
 
-# update security libraries in the base image
-ENV NSLOTS 4
-
-# -----------------------------------------
+# TODO what is this for?
+ENV NSLOTS=4
 
 WORKDIR /kb/module
 
@@ -22,10 +13,6 @@ COPY ./ /kb/module
 
 # add SAMTools (don't need yet)
 #RUN apt-get update && apt-get install -y samtools
-
-# needed for python3 base image
-#RUN apt-get update && apt-get install -y wget gcc
-
 
 # install BBTools
 
@@ -38,6 +25,9 @@ RUN BBMAP_VERSION=$(cat /kb/module/bbmap_version) \
 # build BBTools small C-lib
 RUN cd /kb/module/bbmap/jni \
     && make -f makefile.linux
+	
+# Per BB, don't use this, removed in later versions. Causing test failures
+RUN sed -i 's/jni=t//g' /kb/module/bbmap/rqcfilter2.sh
 
 # copy local ref files
 RUN mkdir /global

--- a/README.md
+++ b/README.md
@@ -54,12 +54,20 @@ The result of an RQCFilter run is a structure with the following keys:
 All of the output directory info should be available from your SDK module's file system.
 
 # How to Update
-There's a few caveats for updating the version of BBTools being used here. Here's the steps to follow.
-1. Update Dockerfile.  
-The version downloaded is embedded in the `Dockerfile` for this repo, line 29. Bump that version to whatever you need.
+There's a few caveats for updating the version of BBTools being used here. Here's the steps to
+follow.
+1. Update the `bbmap_version` file with the targeted version.
 2. Update App Spec.  
-The version is also added to `ui/narrative/methods/RQCFilter/display.yaml`, line 4. Update that there to display the version of BBTools being run.
+The version is also added to `ui/narrative/methods/RQCFilter/display.yaml`, line 4.
+Update that there to display the version of BBTools being run.
 3. Update kbase.yml  
-The `module-version` in `kbase.yml` should also be bumped. It follows semantic versioning, so if you're just bumping the BBTools version, then a patch upgrade is most appropriate.
+The `module-version` in `kbase.yml` should also be bumped. It follows semantic versioning,
+so if you're just bumping the BBTools version, then a patch upgrade is most appropriate.
 4. (optional) Update reference data.  
-If the reference data changes - either in the large tar file hosted at NERSC, or what's packaged with bbmap, this gets slightly more complex. The file `scripts/load_reference_data.sh` works outside of the module compile process, so it maintains its own version of things. There's a version of BBTools embedded there as well, so that will need to change if the bundled data is updated. Finally, you'll have to increase the value of the `data-version` line in `kbase.yml` for the reference data to be re-downloaded.
+If the reference data changes - either in the large tar file hosted at NERSC, or what's
+packaged with bbmap, this gets slightly more complex. The file
+`scripts/load_reference_data.sh` downloads and sets up the reference data. If the url for
+the large reference data tar file changes you'll need to change it there.
+Finally, you'll have to increase the value of the `data-version` line in `kbase.yml`
+for the reference data to be re-downloaded when running an app, whether due to a change in
+the reference data tar file or the data bundled with BBTools.

--- a/lib/BBTools/utils/BBMapRunner.py
+++ b/lib/BBTools/utils/BBMapRunner.py
@@ -7,7 +7,7 @@ from pprint import pprint
 
 from BBTools.utils.BBToolsRunner import BBToolsRunner
 from installed_clients.KBaseReportClient import KBaseReport
-from commandbuilder import build_options
+from .commandbuilder import build_options
 from .file_util import (
     download_assemblies,
     download_assembly,

--- a/lib/BBTools/utils/BBToolsRunner.py
+++ b/lib/BBTools/utils/BBToolsRunner.py
@@ -19,8 +19,8 @@ class BBToolsRunner:
         """
         command = [os.path.join(self.BBTOOLS_PATH, command)] + options
 
-        print('In working directory: ' + ' '.join(command))
-        print('Running: ' + ' '.join(command))
+        print('In working directory: ' + self.scratch_dir)
+        print('Running: ' + ' '.join(command), flush=True)  # otherwise interleaves with BB out
 
         p = subprocess.Popen(command, cwd=self.scratch_dir, shell=False)
         exitCode = p.wait()

--- a/lib/BBTools/utils/MemEstimatorRunner.py
+++ b/lib/BBTools/utils/MemEstimatorRunner.py
@@ -38,8 +38,8 @@ class MemEstimatorRunner(object):
         if self.file2:
             cmd.append("in2="+self.file2)
         cmd.append("cardinality")
-        process = subprocess.Popen(cmd, stderr=subprocess.PIPE)
-        output = str(process.communicate()[1])
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True)
+        output = process.communicate()[1]
 
         m = re.search(r'Unique 31-mers:\s*(\d+)', output)
         if m is not None:

--- a/lib/BBTools/utils/RQCFilterRunner.py
+++ b/lib/BBTools/utils/RQCFilterRunner.py
@@ -6,7 +6,7 @@ from pprint import pprint
 
 from BBTools.utils.BBToolsRunner import BBToolsRunner
 from installed_clients.KBaseReportClient import KBaseReport
-from commandbuilder import build_options
+from .commandbuilder import build_options
 from .file_util import (
     download_interleaved_reads,
     upload_interleaved_reads,
@@ -132,6 +132,10 @@ class RQCFilterRunner:
                 raise ValueError('The value of maxmem must be an integer > 0.')
 
         options = build_options(app_params, available_params)
+        
+        # Don't use JNI per BB. Obsoleted in later versions
+        # Causing test failures in the current version (38.73)
+        options.append("jni=f")
 
         # setup input/output paths
         options.append('in={}'.format(reads_file))

--- a/scripts/load_reference_data.sh
+++ b/scripts/load_reference_data.sh
@@ -2,7 +2,7 @@
 
 # data directory is always mounted in the /data
 
-BBMAP_VERSION=38.73
+BBMAP_VERSION=$(cat /kb/module/bbmap_version)
 
 check_exists() {
     if ! [ -d $1 ] ; then

--- a/scripts/prepare_deploy_cfg.py
+++ b/scripts/prepare_deploy_cfg.py
@@ -1,9 +1,9 @@
-import sys
-import os
+import io
 import os.path
+import sys
+from configparser import ConfigParser
+
 from jinja2 import Template
-from ConfigParser import ConfigParser
-import StringIO
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -20,22 +20,11 @@ if __name__ == "__main__":
     elif "KBASE_ENDPOINT" in os.environ:
         kbase_endpoint = os.environ.get("KBASE_ENDPOINT")
         props = "[global]\n" + \
-                "kbase_endpoint = " + kbase_endpoint + "\n" + \
                 "job_service_url = " + kbase_endpoint + "/userandjobstate\n" + \
                 "workspace_url = " + kbase_endpoint + "/ws\n" + \
                 "shock_url = " + kbase_endpoint + "/shock-api\n" + \
-                "handle_url = " + kbase_endpoint + "/handle_service\n" + \
-                "srv_wiz_url = " + kbase_endpoint + "/service_wizard\n" + \
-                "njsw_url = " + kbase_endpoint + "/njs_wrapper\n"
-        if "AUTH_SERVICE_URL" in os.environ:
-            props += "auth_service_url = " + os.environ.get("AUTH_SERVICE_URL") + "\n"
-        props += "auth_service_url_allow_insecure = " + \
-                 os.environ.get("AUTH_SERVICE_URL_ALLOW_INSECURE", "false") + "\n"
-        for key in os.environ:
-            if key.startswith('KBASE_SECURE_CONFIG_PARAM_'):
-                param_name = key[len('KBASE_SECURE_CONFIG_PARAM_'):]
-                props += param_name + " = " + os.environ.get(key) + "\n"
-        config.readfp(StringIO.StringIO(props))
+                "kbase_endpoint = " + kbase_endpoint + "\n"
+        config.read(io.StringIO(props))
     else:
         raise ValueError('Neither ' + sys.argv[2] + ' file nor KBASE_ENDPOINT env-variable found')
     props = dict(config.items("global"))

--- a/test/BBTools_server_test.py
+++ b/test/BBTools_server_test.py
@@ -236,7 +236,7 @@ class BBToolsTest(unittest.TestCase):
             "read_library_ref": "{}/{}/{}".format(lib_info[6], lib_info[0], lib_info[4]),
         }
         bbtools = self.getImpl()
-        res = bbtools.run_RQCFilter_local(self.ctx, io_params, { "maxmem": 5 })
+        res = bbtools.run_RQCFilter_local(self.ctx, io_params, { "maxmem": 5 })[0]
         self.assertIn('output_directory', res)
         self.assertIn('filtered_fastq_file', res)
         self.assertIn('run_log', res)


### PR DESCRIPTION
1 test is still failing due to a heap error. The py module code is setting the max heap to 5G which I guess isn't enough, need to dig into that more.

Can't update java further since java 9 breaks the kb-sdk

Need a new base image for py 3.8+

Also made the refdata stager use the `bbmap_version` file

Fixes #43 